### PR TITLE
Use light slider and drop filter options

### DIFF
--- a/mirror-app-ios/SettingsView.swift
+++ b/mirror-app-ios/SettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Settings screen allowing theme selection and showing legal text.
 struct SettingsView: View {
     /// Persisted application theme.
-    @AppStorage("appTheme") private var appTheme: Theme = .light
+    @AppStorage("appTheme") private var appTheme: Theme = .pink
 
     /// Localized display names for the themes.
     private var themeNames: [Theme: String] {

--- a/mirror-app-ios/SplashView.swift
+++ b/mirror-app-ios/SplashView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 /// Initial splash screen shown on app launch
 struct SplashView: View {
-    /// Persisted application theme (defaults to light)
-    @AppStorage("appTheme") private var appTheme: Theme = .light
+    /// Persisted application theme (defaults to pink)
+    @AppStorage("appTheme") private var appTheme: Theme = .pink
     /// Controls navigation to the camera preview screen
     @State private var navigateToCamera: Bool = false
 


### PR DESCRIPTION
## Summary
- Replace light toggle with intensity slider overlaying color and persistent slider control
- Remove filter buttons and processing logic
- Default to pink theme across splash, settings, and camera views

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac69ef3da8832f8ede45f49c2db28d