### PR TITLE
Simplify preview mirroring toggle

### DIFF
--- a/mirror-app-ios/CameraPreviewView.swift
+++ b/mirror-app-ios/CameraPreviewView.swift
@@ -186,9 +186,7 @@ final class CameraSessionController: NSObject, ObservableObject {
     func toggleMirroring() {
         guard let connection = previewLayer.connection else { return }
         if connection.isVideoMirroringSupported {
-            connection.automaticallyAdjustsVideoMirroring = false
             connection.isVideoMirrored.toggle()
-            print("Mirroring toggled: \(connection.isVideoMirrored)") // デバッグログ
         }
     }
 }


### PR DESCRIPTION
## Summary
- Default front-camera preview mirrors like the stock Camera app
- Add a simple toggle to switch between mirrored and real previews without affecting captured images

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68adafb7b638832fa72e822b8198fada